### PR TITLE
Public 데코레이터 추가 및 GetUser데코레이터 Failover처리 수정

### DIFF
--- a/src/common/decorators/getUser.decorator.ts
+++ b/src/common/decorators/getUser.decorator.ts
@@ -1,4 +1,8 @@
-import { ExecutionContext, createParamDecorator } from '@nestjs/common';
+import {
+  ExecutionContext,
+  UnauthorizedException,
+  createParamDecorator,
+} from '@nestjs/common';
 import { ReqUserPayload } from '../types/type';
 import { Request } from 'express';
 
@@ -19,6 +23,9 @@ export const GetUser = createParamDecorator(
 
     // Expect Request, user property as type 'ReqUserPayload'(Refer to defined in common/types/type.d.ts)
     const user: Express.User = request.user;
+    if (!user) {
+      throw new UnauthorizedException('인증에 실패하였습니다.');
+    }
     return user['id'];
   },
 );

--- a/src/common/decorators/index.ts
+++ b/src/common/decorators/index.ts
@@ -1,1 +1,2 @@
 export * from './getUser.decorator';
+export * from './public.decorator';

--- a/src/common/decorators/public.decorator.ts
+++ b/src/common/decorators/public.decorator.ts
@@ -1,0 +1,11 @@
+import { SetMetadata } from '@nestjs/common';
+
+/**
+ * @Public Decorator
+ *
+ * Controller레벨 혹은 애플리케이션 Global Guard가 걸려있는 경우
+ * 특정 Route에 대해 Public을 허용할 수 있게 하기 위해 사용합니다.
+ */
+
+export const PublicRouteToken = 'public-route';
+export const Public = () => SetMetadata(PublicRouteToken, true);

--- a/src/common/decorators/public.decorator.ts
+++ b/src/common/decorators/public.decorator.ts
@@ -7,5 +7,5 @@ import { SetMetadata } from '@nestjs/common';
  * 특정 Route에 대해 Public을 허용할 수 있게 하기 위해 사용합니다.
  */
 
-export const PublicRouteToken = 'public-route';
+export const PublicRouteToken = Symbol('public-route');
 export const Public = () => SetMetadata(PublicRouteToken, true);

--- a/src/modules/users/guards/jwt.guard.ts
+++ b/src/modules/users/guards/jwt.guard.ts
@@ -1,11 +1,33 @@
 import { AuthGuard } from '@nestjs/passport';
-import { Injectable } from '@nestjs/common';
+import { ExecutionContext, Injectable } from '@nestjs/common';
 import { Reflector } from '@nestjs/core';
 import { JWT_STRATEGY_TOKEN } from '@src/modules/users/guards/strategy/strategy.token';
+import { PublicRouteToken } from '@src/common';
 
 @Injectable()
 export class JwtGuard extends AuthGuard(JWT_STRATEGY_TOKEN) {
   constructor(private readonly reflector: Reflector) {
     super();
+  }
+
+  async canActivate(context: ExecutionContext): Promise<boolean> {
+    // Handler 혹은 Class중 하나만 정의되어있다면 boolean으로 둘다 정의되어있다면 array([boolean,boolean])로 옵니다
+    const publicMetadata = this.reflector.getAllAndMerge(PublicRouteToken, [
+      context.getClass(),
+      context.getHandler(),
+    ]);
+
+    // Handler와 Class모두 메타데이터가 정의되어있는 경우
+    if (
+      (Array.isArray(publicMetadata) && publicMetadata.length) ||
+      typeof publicMetadata === 'boolean'
+    ) {
+      try {
+        return (await super.canActivate(context)) as boolean;
+      } catch (err) {
+        return true;
+      }
+    }
+    return (await super.canActivate(context)) as boolean;
   }
 }


### PR DESCRIPTION
## PR 내용

## 추가 및 변경 사항

- `@Public()`데코레이터 추가
  - 용도: Controller레벨 혹은 애플리케이션 레벨에서 Guard를 걸어둔 상태에서 특정 Route를 Public(인증 없어도 호출 가능)을 허용하거나 테스트용으로 활용하기 위해서 추가
  - 사용예시
 
```typescript
@FolderControllerDocs
@UseGuards(JwtGuard)
@Controller('folders')
export class FoldersController {
  constructor(private readonly foldersService: FoldersService) {}

  @CreateFolderDocs
  @Post()
  @Public() // 해당 Route는 인증없이도 호출 가능
  async create(
    @GetUser('id') userId: Types.ObjectId,
    @Body() createFolderDto: MutateFolderDto,
  ) {
    await this.foldersService.create(userId, createFolderDto);
    return true;
  }

```

- `@GetUser` 데코레이터 Failover처리
  - `@GetUser`에서 인증이 되지 않은 상태로 사용자 ID 호출 시도시 예외 반환하도록 수정

```typescript
    // Expect Request, user property as type 'ReqUserPayload'(Refer to defined in common/types/type.d.ts)
    const user: Express.User = request.user;
   // 변경된 부분
    if (!user) {
      throw new UnauthorizedException('인증에 실패하였습니다.');
    }
    return user['id'];
``` 

## PR 중점사항

> 리뷰어가 중점적으로 봐야하는 부분에 대해 적어주세요!

## 스크린샷
