### PR TITLE
Update Post API 생성, 기존 Update Post API Update Post Folder로 명명 변경

### DIFF
--- a/src/modules/posts/dto/index.ts
+++ b/src/modules/posts/dto/index.ts
@@ -1,3 +1,4 @@
 export * from './create-post.dto';
-export * from './update-post.dto';
+export * from './updatePostFolder.dto';
 export * from './list-post.dto';
+export * from './updatePost.dto';

--- a/src/modules/posts/dto/updatePost.dto.ts
+++ b/src/modules/posts/dto/updatePost.dto.ts
@@ -1,0 +1,15 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { PostUpdateableFields } from '../type/type';
+import { IsBoolean, IsOptional } from 'class-validator';
+
+export class UpdatePostDto implements PostUpdateableFields {
+  // Temporary ignore in MVP level
+  title: string;
+  @ApiProperty({
+    required: false,
+    default: false,
+  })
+  @IsOptional()
+  @IsBoolean()
+  isFavorite: boolean;
+}

--- a/src/modules/posts/dto/updatePostFolder.dto.ts
+++ b/src/modules/posts/dto/updatePostFolder.dto.ts
@@ -1,7 +1,7 @@
 import { ApiProperty } from '@nestjs/swagger';
 import { IsMongoId, IsNotEmpty } from 'class-validator';
 
-export class UpdatePostDto {
+export class UpdatePostFolderDto {
   @IsNotEmpty()
   @IsMongoId()
   @ApiProperty()

--- a/src/modules/posts/posts.controller.ts
+++ b/src/modules/posts/posts.controller.ts
@@ -13,7 +13,7 @@ import { PostsService } from '@src/modules/posts/posts.service';
 import { CreatePostDto } from '@src/modules/posts/dto/create-post.dto';
 import { GetUser, PaginationMetadata } from '@src/common';
 import { JwtGuard } from '@src/modules/users/guards';
-import { ListPostQueryDto, UpdatePostDto } from './dto';
+import { ListPostQueryDto, UpdatePostDto, UpdatePostFolderDto } from './dto';
 import {
   CreatePostDocs,
   DeletePostDocs,
@@ -47,12 +47,21 @@ export class PostsController {
     return await this.postsService.createPost(createPostDto, userId);
   }
 
+  @Patch(':postId')
+  async updateFolder(
+    @GetUser() userId: string,
+    @Param('postId') postId: string,
+    @Body() dto: UpdatePostDto,
+  ) {
+    return await this.postsService.updatePost(userId, postId, dto);
+  }
+
   @Patch(':postId/move')
   @UpdatePostFolderDocs
   async updatePostFolder(
     @GetUser() userId: string,
     @Param('postId') postId: string,
-    @Body() dto: UpdatePostDto,
+    @Body() dto: UpdatePostFolderDto,
   ) {
     return await this.postsService.updatePostFolder(userId, postId, dto);
   }

--- a/src/modules/posts/posts.repository.ts
+++ b/src/modules/posts/posts.repository.ts
@@ -7,6 +7,7 @@ import { InjectModel } from '@nestjs/mongoose';
 import { FilterQuery, Model } from 'mongoose';
 import { Post } from '@src/infrastructure';
 import { OrderType } from '@src/common';
+import { PostUpdateableFields } from './type/type';
 
 @Injectable()
 export class PostsRepository {
@@ -93,7 +94,34 @@ export class PostsRepository {
     }
   }
 
-  async deletePost(userId: string, postId: string) {
+  async updatePost(
+    userId: string,
+    postId: string,
+    updateFields: PostUpdateableFields,
+  ) {
+    const updateResult = await this.postModel
+      .updateOne(
+        {
+          _id: postId,
+          userId: userId,
+        },
+        {
+          $set: {
+            ...updateFields,
+          },
+        },
+      )
+      .exec();
+
+    if (!updateResult.modifiedCount) {
+      throw new NotFoundException('Post를 찾을 수 없습니다.');
+    }
+    return updateResult;
+  }
+
+  // 해당 이슈로 인해 임시로 any타입 명시
+  // https://github.com/microsoft/TypeScript/issues/42873
+  async deletePost(userId: string, postId: string): Promise<any> {
     const deleteResult = await this.postModel
       .deleteOne({
         _id: postId,

--- a/src/modules/posts/posts.service.ts
+++ b/src/modules/posts/posts.service.ts
@@ -1,7 +1,7 @@
 import { Injectable } from '@nestjs/common';
 import { CreatePostDto } from '@src/modules/posts/dto/create-post.dto';
 import { PostsRepository } from '@src/modules/posts/posts.repository';
-import { ListPostQueryDto, UpdatePostDto } from './dto';
+import { ListPostQueryDto, UpdatePostDto, UpdatePostFolderDto } from './dto';
 
 @Injectable()
 export class PostsService {
@@ -39,7 +39,21 @@ export class PostsService {
     );
   }
 
-  async updatePostFolder(userId: string, postId: string, dto: UpdatePostDto) {
+  async updatePost(userId: string, postId: string, dto: UpdatePostDto) {
+    // Find if user post exist
+    await this.postRepository.findPostOrThrow(userId, postId);
+
+    // Update post data
+    await this.postRepository.updatePost(userId, postId, dto);
+
+    return true;
+  }
+
+  async updatePostFolder(
+    userId: string,
+    postId: string,
+    dto: UpdatePostFolderDto,
+  ) {
     // Find if post exist
     await this.postRepository.findPostOrThrow(userId, postId);
 

--- a/src/modules/posts/type/type.d.ts
+++ b/src/modules/posts/type/type.d.ts
@@ -1,2 +1,4 @@
+import { Post } from '@src/infrastructure';
+
 export interface PostUpdateableFields
   extends Pick<Post, 'title' | 'isFavorite'> {}


### PR DESCRIPTION
## PR 내용

## 추가 및 변경 사항

- 즐겨찾기 상태 변경 API가 없어서 해당 사항 변경할 수 있는 API 생성
- 기존 updatePost API는 updatePostFolder로 변경 + Route를 `post/:postId/move`로 변경

## PR 중점사항

> 리뷰어가 중점적으로 봐야하는 부분에 대해 적어주세요!

## 스크린샷
