### PR TITLE
refactor/post: 피드 생성 시 URL open-graph 이미지 url, 요약 상태 필드추가, 전체 피드 조회 시에도 해당 응답 키 값추가

### DIFF
--- a/src/ai_handler.ts
+++ b/src/ai_handler.ts
@@ -5,7 +5,7 @@ import { AppModule } from '@src/app.module';
 import { LambdaEventPayload } from './infrastructure/aws-lambda/type';
 import { ClassficiationRepository } from './modules/classification/classification.repository';
 import { PostsRepository } from './modules/posts/posts.repository';
-import { PostAIStatus } from '@src/modules/posts/posts.constant';
+import { PostAiStatus } from '@src/modules/posts/posts.constant';
 
 export const handler: Handler = async (event: LambdaEventPayload) => {
   const app = await NestFactory.create(AppModule);
@@ -27,7 +27,7 @@ export const handler: Handler = async (event: LambdaEventPayload) => {
   );
   const postId = event.postId;
   let classificationId = null;
-  let postAIStatus = PostAIStatus.FAIL;
+  let postAiStatus = PostAiStatus.FAIL;
 
   // NOTE : 요약 성공 시 classification 생성, post 업데이트
   if (summarizeUrlContent.success) {
@@ -40,10 +40,10 @@ export const handler: Handler = async (event: LambdaEventPayload) => {
       folderId,
     );
     classificationId = classification._id.toString();
-    postAIStatus = PostAIStatus.SUCCESS;
+    postAiStatus = PostAiStatus.SUCCESS;
   }
   await postRepository.updatePostClassificationForAIClassification(
-    postAIStatus,
+    postAiStatus,
     postId,
     classificationId,
     summarizeUrlContent.response.summary,

--- a/src/infrastructure/database/schema/post.schema.ts
+++ b/src/infrastructure/database/schema/post.schema.ts
@@ -2,7 +2,7 @@ import { Prop, Schema, SchemaFactory } from '@nestjs/mongoose';
 import { HydratedDocument, Schema as MongooseSchema } from 'mongoose';
 import { BaseDocument } from './base.schema';
 import { AIClassification } from './AIClassification.schema';
-import { PostAIStatus } from '@src/modules/posts/posts.constant';
+import { PostAiStatus } from '@src/modules/posts/posts.constant';
 
 @Schema({ collection: 'posts', timestamps: true, versionKey: false })
 export class Post extends BaseDocument {
@@ -30,8 +30,8 @@ export class Post extends BaseDocument {
   @Prop({ required: false, type: String })
   thumbnailImgUrl?: string | null;
 
-  @Prop({ required: true, enum: PostAIStatus, type: String })
-  postAIStatus: PostAIStatus;
+  @Prop({ required: true, enum: PostAiStatus, type: String })
+  aiStatus: PostAiStatus;
 
   @Prop({
     required: false,

--- a/src/infrastructure/database/schema/post.schema.ts
+++ b/src/infrastructure/database/schema/post.schema.ts
@@ -2,6 +2,7 @@ import { Prop, Schema, SchemaFactory } from '@nestjs/mongoose';
 import { HydratedDocument, Schema as MongooseSchema } from 'mongoose';
 import { BaseDocument } from './base.schema';
 import { AIClassification } from './AIClassification.schema';
+import { PostAIStatus } from '@src/modules/posts/posts.constant';
 
 @Schema({ collection: 'posts', timestamps: true, versionKey: false })
 export class Post extends BaseDocument {
@@ -25,6 +26,12 @@ export class Post extends BaseDocument {
 
   @Prop({ default: null })
   readAt: Date;
+
+  @Prop({ required: false, type: String })
+  thumbnailImgUrl?: string | null;
+
+  @Prop({ required: true, enum: PostAIStatus, type: String })
+  postAIStatus: PostAIStatus;
 
   @Prop({
     required: false,

--- a/src/modules/posts/posts.constant.ts
+++ b/src/modules/posts/posts.constant.ts
@@ -1,4 +1,4 @@
-export enum PostAIStatus {
+export enum PostAiStatus {
   IN_PROGRES = 'in_progress',
   SUCCESS = 'success',
   FAIL = 'fail',

--- a/src/modules/posts/posts.constant.ts
+++ b/src/modules/posts/posts.constant.ts
@@ -1,0 +1,5 @@
+export enum PostAIStatus {
+  IN_PROGRES = 'in_progress',
+  SUCCESS = 'success',
+  FAIL = 'fail',
+}

--- a/src/modules/posts/posts.repository.ts
+++ b/src/modules/posts/posts.repository.ts
@@ -340,9 +340,10 @@ export class PostsRepository {
   }
 
   async updatePostClassificationForAIClassification(
-    postId: string,
-    classificationId: string,
-    description: string,
+    postAIStatus: PostAIStatus,
+    postId: string | null,
+    classificationId: string | null,
+    description: string | null,
   ) {
     const updatedPost = await this.postModel
       .updateOne(
@@ -353,6 +354,7 @@ export class PostsRepository {
           $set: {
             aiClassificationId: classificationId,
             description: description,
+            postAIStatus: postAIStatus,
           },
         },
       )

--- a/src/modules/posts/posts.repository.ts
+++ b/src/modules/posts/posts.repository.ts
@@ -12,7 +12,7 @@ import {
 } from '../classification/dto/classification.dto';
 import { OrderType } from '@src/common';
 import { PostUpdateableFields } from './type/type';
-import { PostAIStatus } from '@src/modules/posts/posts.constant';
+import { PostAiStatus } from '@src/modules/posts/posts.constant';
 
 @Injectable()
 export class PostsRepository {
@@ -92,7 +92,7 @@ export class PostsRepository {
     url: string,
     title: string,
     thumbnail: string,
-    postAIStatus: PostAIStatus,
+    postAIStatus: PostAiStatus,
   ): Promise<string> {
     try {
       const postModel = await this.postModel.create({
@@ -102,7 +102,7 @@ export class PostsRepository {
         userId: userId,
         readAt: null,
         thumbnailImgUrl: thumbnail,
-        postAIStatus: postAIStatus,
+        aiStatus: postAIStatus,
       });
       return postModel._id.toString();
     } catch (error) {
@@ -340,7 +340,7 @@ export class PostsRepository {
   }
 
   async updatePostClassificationForAIClassification(
-    postAIStatus: PostAIStatus,
+    postAiStatus: PostAiStatus,
     postId: string | null,
     classificationId: string | null,
     description: string | null,
@@ -354,7 +354,7 @@ export class PostsRepository {
           $set: {
             aiClassificationId: classificationId,
             description: description,
-            postAIStatus: postAIStatus,
+            aiStatus: postAiStatus,
           },
         },
       )

--- a/src/modules/posts/posts.repository.ts
+++ b/src/modules/posts/posts.repository.ts
@@ -12,6 +12,7 @@ import {
 } from '../classification/dto/classification.dto';
 import { OrderType } from '@src/common';
 import { PostUpdateableFields } from './type/type';
+import { PostAIStatus } from '@src/modules/posts/posts.constant';
 
 @Injectable()
 export class PostsRepository {
@@ -90,6 +91,8 @@ export class PostsRepository {
     folderId: string,
     url: string,
     title: string,
+    thumbnail: string,
+    postAIStatus: PostAIStatus,
   ): Promise<string> {
     try {
       const postModel = await this.postModel.create({
@@ -98,6 +101,8 @@ export class PostsRepository {
         title: title,
         userId: userId,
         readAt: null,
+        thumbnailImgUrl: thumbnail,
+        postAIStatus: postAIStatus,
       });
       return postModel._id.toString();
     } catch (error) {

--- a/src/modules/posts/posts.service.ts
+++ b/src/modules/posts/posts.service.ts
@@ -7,7 +7,7 @@ import { ListPostQueryDto, UpdatePostDto, UpdatePostFolderDto } from './dto';
 import { AwsLambdaService } from '@src/infrastructure/aws-lambda/aws-lambda.service';
 import { parseLinkTitleAndContent } from '@src/common';
 import { ConfigService } from '@nestjs/config';
-import { PostAIStatus } from '@src/modules/posts/posts.constant';
+import { PostAiStatus } from '@src/modules/posts/posts.constant';
 
 @Injectable()
 export class PostsService {
@@ -57,7 +57,7 @@ export class PostsService {
       createPostDto.url,
       title,
       thumbnail,
-      PostAIStatus.IN_PROGRES,
+      PostAiStatus.IN_PROGRES,
     );
     const payload = {
       postContent: content,

--- a/src/modules/posts/posts.service.ts
+++ b/src/modules/posts/posts.service.ts
@@ -7,6 +7,7 @@ import { ListPostQueryDto, UpdatePostDto, UpdatePostFolderDto } from './dto';
 import { AwsLambdaService } from '@src/infrastructure/aws-lambda/aws-lambda.service';
 import { parseLinkTitleAndContent } from '@src/common';
 import { ConfigService } from '@nestjs/config';
+import { PostAIStatus } from '@src/modules/posts/posts.constant';
 
 @Injectable()
 export class PostsService {
@@ -38,31 +39,35 @@ export class PostsService {
     createPostDto: CreatePostDto,
     userId: string,
   ): Promise<boolean> {
-    const { title, content } = await parseLinkTitleAndContent(
+    // NOTE : URL에서 얻은 정보 가져옴
+    const { title, content, thumbnail } = await parseLinkTitleAndContent(
       createPostDto.url,
     );
 
-    const userFolders = await this.folderRepository.findByUserId(userId);
-    const folders = userFolders.map((folder) => {
+    const userFolderList = await this.folderRepository.findByUserId(userId);
+    const folderList = userFolderList.map((folder) => {
       return {
         id: folder._id.toString(),
         name: folder.name,
       };
     });
-    const aiLambdaFunctionName = this.config.get<string>(
-      'LAMBDA_FUNCTION_NAME',
-    );
     const postId = await this.postRepository.createPost(
       userId,
       createPostDto.folderId,
       createPostDto.url,
       title,
+      thumbnail,
+      PostAIStatus.IN_PROGRES,
     );
     const payload = {
       postContent: content,
-      folderList: folders,
+      folderList: folderList,
       postId: postId,
     };
+
+    const aiLambdaFunctionName = this.config.get<string>(
+      'LAMBDA_FUNCTION_NAME',
+    );
     await this.awsLambdaService.invokeLambda(aiLambdaFunctionName, payload);
     return true;
   }

--- a/src/modules/posts/response/listPost.response.ts
+++ b/src/modules/posts/response/listPost.response.ts
@@ -2,7 +2,7 @@ import { ApiProperty } from '@nestjs/swagger';
 import { PaginationMetadata } from '@src/common';
 import { Post } from '@src/infrastructure';
 import { Types } from 'mongoose';
-import { PostAIStatus } from '@src/modules/posts/posts.constant';
+import { PostAiStatus } from '@src/modules/posts/posts.constant';
 
 export class ListPostItem {
   @ApiProperty()
@@ -33,10 +33,10 @@ export class ListPostItem {
 
   @ApiProperty({
     required: true,
-    enum: PostAIStatus,
+    enum: PostAiStatus,
     description: '피드 게시글의 ai 진행 상태',
   })
-  postAIStatus: PostAIStatus;
+  aiStatus: PostAiStatus;
 
   constructor(data: Post & { _id: Types.ObjectId }) {
     this.id = data._id.toString();
@@ -47,7 +47,7 @@ export class ListPostItem {
     this.isFavorite = data.isFavorite;
     this.readAt = data.readAt;
     this.thumbnail_img_url = data.thumbnailImgUrl;
-    this.postAIStatus = data.postAIStatus;
+    this.aiStatus = data.aiStatus;
   }
 }
 

--- a/src/modules/posts/response/listPost.response.ts
+++ b/src/modules/posts/response/listPost.response.ts
@@ -2,6 +2,7 @@ import { ApiProperty } from '@nestjs/swagger';
 import { PaginationMetadata } from '@src/common';
 import { Post } from '@src/infrastructure';
 import { Types } from 'mongoose';
+import { PostAIStatus } from '@src/modules/posts/posts.constant';
 
 export class ListPostItem {
   @ApiProperty()
@@ -27,6 +28,16 @@ export class ListPostItem {
   })
   readAt: Date;
 
+  @ApiProperty({ required: false, description: 'URL og 이미지' })
+  thumbnail_img_url: string;
+
+  @ApiProperty({
+    required: true,
+    enum: PostAIStatus,
+    description: '피드 게시글의 ai 진행 상태',
+  })
+  postAIStatus: PostAIStatus;
+
   constructor(data: Post & { _id: Types.ObjectId }) {
     this.id = data._id.toString();
     this.folderId = data.folderId.toString();
@@ -35,6 +46,8 @@ export class ListPostItem {
     this.description = data.description;
     this.isFavorite = data.isFavorite;
     this.readAt = data.readAt;
+    this.thumbnail_img_url = data.thumbnailImgUrl;
+    this.postAIStatus = data.postAIStatus;
   }
 }
 


### PR DESCRIPTION
## PR 내용

## 추가 및 변경 사항

> [POST] post API(피드 생성) 시 ai 요약상태를 in_progress 상태로 저장, URL의 thumbnail image 추가
> [GET] post API (게시글 조회)시 두 상태값 응답에 추가
> [ai-worker] 람다에서 ai 요약 성공, 실패에 대한 post 업데이트 추가 (success, fail)

## PR 중점사항
> post 응답값이 바뀌면서 다른 도메인에도 post 정보 조회하는곳에서 thumbnail_image_url 필드랑  postAIStatus 필드 추가가 필요한데
내가 또 다 바꾸면 에러가 죄다 날꺼라... 도메인 담당자들이 변경 좀 부탁해요~ @hye-on , @Marades , @J-Hoplin 

## 스크린샷
